### PR TITLE
📝 Add 📦 emoji to task group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,6 @@
 
 ## Unreleased
 
+- 📝 Added 📦 emoji to task group. #15
+- 🚰 [Tube](https://github.com/phatblat/Tube) #14
 - ⬆️ Kotlin (1.2.31). #13

--- a/src/main/kotlin/at/phatbl/swiftpm/Constants.kt
+++ b/src/main/kotlin/at/phatbl/swiftpm/Constants.kt
@@ -5,7 +5,7 @@ package at.phatbl.swiftpm
  */
 class Constants {
     companion object {
-        const val SWIFTPM_TASK_GROUP = "SwiftPM"
+        const val SWIFTPM_TASK_GROUP = "📦 SwiftPM"
 
         // SwiftPM task names
         const val SPM_TASK_PREFIX = "swiftpm"


### PR DESCRIPTION
Not only does this look better but it causes the tasks to be listed towards the end.

![screen shot 2018-03-30 at 4 38 27 pm](https://user-images.githubusercontent.com/28851/38156098-caa8da92-3438-11e8-8bb5-3640ca55d40b.png)
