### PR TITLE
⬆️ Bintray (1.8.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- ⬆️ Bintray (1.8.4)
+
 ## 1.2.0
 
 - ✨ Init command #27

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ plugins {
 
     // Gradle plugin portal - https://plugins.gradle.org/
     kotlin("jvm") version "1.2.41"
-    id("com.jfrog.bintray") version "1.8.0"
+    id("com.jfrog.bintray") version "1.8.4"
     id("com.gradle.plugin-publish") version "0.9.10"
 
     // Custom handling in pluginManagement


### PR DESCRIPTION
Resolves issue trying to publish 1.2.0 using Bintray 1.8.0:

> Caused by: org.gradle.api.GradleException: Could not upload to 'https://api.bintray.com/content/phatblat/maven-open-source/SwiftPM/1.2.0/property(class java/lang/String, map(provider(?)))/property(class java.lang.String, fixed(class java.lang.String, swiftpm))/property(class java.lang.String, map(provider(?)))/property(class java.lang.String, fixed(class java.lang.String, swiftpm))-property(class java.lang.String, map(provider(?))).pom': HTTP/1.1 400 Bad Request [message:Unable to upload files: Maven group, artifact or version defined in the pom file do not match the file path 'property(class java/lang/String, map(provider(?)))/property(class java.lang.String, fixed(class java.lang.String, swiftpm))/property(class java.lang.String, map(provider(?)))/property(class java.lang.String, fixed(class java.lang.String, swiftpm))-property(class java.lang.String, map(provider(?))).pom']